### PR TITLE
Exception handling for WakeupMonitor

### DIFF
--- a/src/Eventful/Prelude.fs
+++ b/src/Eventful/Prelude.fs
@@ -28,6 +28,11 @@ type Logger internal (name : string) =
             let message = msg.Force()
             logger.Warning(message)
 
+    member this.WarnWithException (msg : Lazy<string * System.Exception>) : unit = 
+        if (logger.IsEnabled(LogEventLevel.Warning)) then
+            let (message, exn) = msg.Force()
+            logger.Warning(message + " {@Exception}", exn)
+
     member this.RichError (msgTemplate : string) args : unit = 
         if (logger.IsEnabled(LogEventLevel.Error)) then
             logger.Error(msgTemplate, args)


### PR DESCRIPTION
WakeupMonitor now survives loss of RavenDB connection and logs the exception as a warning