### PR TITLE
jToken.ToString() capitalization issue on booleans

### DIFF
--- a/src/Eventful.RavenDb/AggregateStatePersistence.fs
+++ b/src/Eventful.RavenDb/AggregateStatePersistence.fs
@@ -40,8 +40,8 @@ module AggregateStatePersistence =
         definition
 
     let deserialize (serializer :  ISerializer) (doc : RavenJObject) (propertyTypes : Map<string,Type>) =
-        let deserializeRavenJToken targetType jToken =
-            jToken.ToString()
+        let deserializeRavenJToken targetType (jToken : RavenJToken) =
+            jToken.ToString(Raven.Imports.Newtonsoft.Json.Formatting.None)
             |> System.Text.Encoding.UTF8.GetBytes
             |> (fun x -> serializer.DeserializeObj x targetType)
 


### PR DESCRIPTION
In [closed Issue 248 Newtonsoft.Json (April 2014)] (https://github.com/JamesNK/Newtonsoft.Json/issues/248) will by design return "True" when the ToString() method is called on the value `true`. This is not suitable for the `deserialize` chain of actions in `AggregateStatePersistence`.

JToken.ToString() supports an overload with `public enum Formatting  {  None, Indented  }` supplying `None` which is not the defaul will give you a value that `JsonSerializer.Deserialize( input, System.Boolean)` will be able to deserialize.

Test to show difference:

        [Test]
        public void JsonTest()
        {
            var data = JToken.FromObject(true);

            var result1 = data.ToString(Newtonsoft.Json.Formatting.None);
            var result2 = data.ToString();

            Assert.AreEqual(result1, result2);
        }

![Test Result](https://cloud.githubusercontent.com/assets/119096/6664111/25f704e2-cc21-11e4-853f-1264f056dee1.png)