### PR TITLE
Clone cached document before updating

### DIFF
--- a/src/BookLibrary/Application.fs
+++ b/src/BookLibrary/Application.fs
@@ -150,7 +150,7 @@ type BookLibraryServiceRunner (applicationConfig : ApplicationConfig) =
                     Serialization.esSerializer
                     system.Handlers
 
-            let cache = new System.Runtime.Caching.MemoryCache("myCache")
+            let cache = new RavenMemoryCache("myCache", documentStore)
 
             let writeQueue = new RavenWriteQueue(documentStore, 100, 10000, 10, Async.DefaultCancellationToken, cache)
             let readQueue = new RavenReadQueue(documentStore, 100, 1000, 10, Async.DefaultCancellationToken, cache)

--- a/src/Eventful.RavenDb/AggregateStatePersistence.fs
+++ b/src/Eventful.RavenDb/AggregateStatePersistence.fs
@@ -182,7 +182,7 @@ module AggregateStatePersistence =
             let documentKey = getDocumentKey streamId
 
             let! doc = 
-                fetcher.GetDocument documentKey
+                fetcher.GetDocument AccessMode.Read documentKey
                 |> Async.AwaitTask
             let typeMap = StateBuilder.getTypeMapFromStateBuilder aggregateConfig.StateBuilder
 

--- a/src/Eventful.RavenDb/BulkRavenProjector.fs
+++ b/src/Eventful.RavenDb/BulkRavenProjector.fs
@@ -37,7 +37,7 @@ module BulkRavenProjector =
             writeQueue.Work databaseName actions
 
         let getPersistedPosition = async {
-            let! (persistedLastComplete : ProjectedDocument<EventPosition> option) = fetcher.GetDocument RavenConstants.PositionDocumentKey |> Async.AwaitTask
+            let! (persistedLastComplete : ProjectedDocument<EventPosition> option) = fetcher.GetDocument AccessMode.Read RavenConstants.PositionDocumentKey |> Async.AwaitTask
             return persistedLastComplete |> Option.map((fun (doc,_,_) -> doc))
         }
 

--- a/src/Eventful.RavenDb/DocumentBuilderProjector.fs
+++ b/src/Eventful.RavenDb/DocumentBuilderProjector.fs
@@ -30,7 +30,7 @@ module DocumentBuilderProjector =
     let processEvents (documentBuilder : DocumentBuilder<'TDocumentKey,'TDocument, 'TMetadata>) documentStore (projectorMessage : MessageOperations<'TMessage, 'TBaseEvent, 'TMetadata>) (documentFetcher:IDocumentFetcher) (key:IComparable) (messages : seq<'TMessage>) = async {
         let key = (key :?> 'TDocumentKey) // presume we get back out what we put in
         let docKey = documentBuilder.GetDocumentKey key
-        let! doc = documentFetcher.GetDocument<'TDocument>(docKey) |> Async.AwaitTask
+        let! doc = documentFetcher.GetDocument<'TDocument> AccessMode.Update docKey |> Async.AwaitTask   // Using AccessMode.Update here because can't guarantee that 'TDocument is immutable
         let (doc, metadata, etag) = 
             match doc with
             | Some x -> x

--- a/src/Eventful.RavenDb/DocumentFetcher.fs
+++ b/src/Eventful.RavenDb/DocumentFetcher.fs
@@ -8,9 +8,17 @@ type DocumentFetcher
     ) =
     
     interface IDocumentFetcher with
-        member x.GetDocument<'TDocument> key = 
+        member x.GetDocument<'TDocument> accessMode key = 
             async {
-                let! result = readQueue.Work databaseName <| Seq.singleton (key, typeof<'TDocument>)
+                let request =
+                    {
+                        DocumentKey = key
+                        DocumentType = typeof<'TDocument>
+                        AccessMode = accessMode
+                    }
+                    |> Seq.singleton
+
+                let! result = readQueue.Work databaseName request
                 let (key, t, result) = Seq.head result
 
                 match result with
@@ -19,6 +27,7 @@ type DocumentFetcher
                 | None -> 
                     return None 
             } |> Async.StartAsTask
+
         member x.GetDocuments request = 
             async {
                 return! readQueue.Work databaseName request 

--- a/src/Eventful.RavenDb/DocumentWriteRequest.fs
+++ b/src/Eventful.RavenDb/DocumentWriteRequest.fs
@@ -7,9 +7,21 @@ open System.Threading.Tasks
 
 type ProjectedDocument<'TDocument> = ('TDocument * Raven.Json.Linq.RavenJObject * Raven.Abstractions.Data.Etag)
 
+[<RequireQualifiedAccess>]
+type AccessMode =
+    | Read       //< Read-only access.
+    | Update     //< Read/write access.
+
+type GetDocRequest =
+    {
+        DocumentKey : string
+        DocumentType : Type
+        AccessMode : AccessMode
+    }
+
 type IDocumentFetcher =
-    abstract member GetDocument<'TDocument> : string -> Task<ProjectedDocument<'TDocument> option> 
-    abstract member GetDocuments : (string * System.Type) seq -> Task<(string * System.Type * Option<obj * RavenJObject * Etag>) seq>
+    abstract member GetDocument<'TDocument> : AccessMode -> string -> Task<ProjectedDocument<'TDocument> option> 
+    abstract member GetDocuments : GetDocRequest seq -> Task<(string * System.Type * Option<obj * RavenJObject * Etag>) seq>
     abstract member GetEmptyMetadata<'TDocument> : unit -> RavenJObject
 
 type DocumentWriteRequest = {

--- a/src/Eventful.RavenDb/RavenReadQueue.fs
+++ b/src/Eventful.RavenDb/RavenReadQueue.fs
@@ -12,7 +12,7 @@ type RavenReadQueue
         maxQueueSize : int,
         workerCount : int,
         cancellationToken : CancellationToken,
-        cache : System.Runtime.Caching.MemoryCache
+        cache : RavenMemoryCache
     ) =
 
     let log = createLogger "Eventful.RavenReadQueue"
@@ -45,7 +45,7 @@ type RavenReadQueue
             for (request, reply) in docs do
                 let responses =
                     request
-                    |> Seq.map (fun (k,_) -> resultMap.Item k)
+                    |> Seq.map (fun { DocumentKey = k } -> resultMap.Item k)
 
                 reply.Reply responses
 
@@ -54,7 +54,7 @@ type RavenReadQueue
         }
         
 
-    let queue = new BatchingQueue<string, seq<string * Type>, seq<GetDocResponse>>(maxBatchSize, maxQueueSize)
+    let queue = new BatchingQueue<string, seq<GetDocRequest>, seq<GetDocResponse>>(maxBatchSize, maxQueueSize)
 
     let consumer = async {
         while true do

--- a/src/Eventful.RavenDb/RavenReadQueue.fs
+++ b/src/Eventful.RavenDb/RavenReadQueue.fs
@@ -21,33 +21,45 @@ type RavenReadQueue
     let batchReadTimer = Metric.Timer("RavenReadQueue Timer", Unit.None)
     let batchReadThroughput = Metric.Meter("RavenReadQueue Documents Read", Unit.Items)
 
-    let readDocs databaseName (docs : seq<(seq<GetDocRequest> * AsyncReplyChannel<seq<GetDocResponse>>)>) : Async<unit>  = 
+    let partition (counts : int seq) (xs : 'a seq) : 'a list list =
+        [
+            let enumerator = xs.GetEnumerator()
+            for count in counts ->
+                [
+                    for i in 1 .. count ->
+                        let hasMore = enumerator.MoveNext()
+                        assert hasMore
+                        enumerator.Current
+                ]
 
-        let request = 
+            let hasMore = enumerator.MoveNext()
+            assert (not hasMore)
+        ]
+
+    let readDocs databaseName (docs : seq<(seq<GetDocRequest> * AsyncReplyChannel<seq<GetDocResponse>>)>) : Async<unit> =
+        let requestsWithReplyChannels =
             docs
-            |> Seq.collect (fun i -> fst i)
+            |> Seq.map (fun (batch, replyChannel) -> (List.ofSeq batch, replyChannel))
             |> List.ofSeq
 
-        let documentCount = int64 request.Length
+        let requests = 
+            requestsWithReplyChannels
+            |> List.collect fst
+
+        let documentCount = int64 requests.Length
         batchReadBatchSizeHistogram.Update(documentCount)
         batchReadThroughput.Mark(documentCount)
            
         async {
             let timer = startNanoSecondTimer()
-            let! getResult = 
-                RavenOperations.getDocuments documentStore cache databaseName request
+            let! getResult = RavenOperations.getDocuments documentStore cache databaseName requests
 
-            let resultMap =
-                getResult
-                |> Seq.map(fun (docId, t, response) -> (docId, (docId, t, response)))
-                |> Map.ofSeq
+            let batchSizes = requestsWithReplyChannels |> Seq.map (fst >> List.length)
+            let partitionedResults = getResult |> partition batchSizes
+            let replyChannels = requestsWithReplyChannels |> Seq.map snd
 
-            for (request, reply) in docs do
-                let responses =
-                    request
-                    |> Seq.map (fun { DocumentKey = k } -> resultMap.Item k)
-
-                reply.Reply responses
+            Seq.zip replyChannels partitionedResults
+            |> Seq.iter (fun (replyChannel, results) -> replyChannel.Reply results)
 
             batchReadTimer.Record(timer(), TimeUnit.Nanoseconds)
             return ()

--- a/src/Eventful.RavenDb/RavenReplayProjector.fs
+++ b/src/Eventful.RavenDb/RavenReplayProjector.fs
@@ -28,7 +28,7 @@ type RavenReplayProjector<'TMessage when 'TMessage :> IBulkMessage>
 
     let fetcher = {
         new IDocumentFetcher with
-            member x.GetDocument<'TDocument> key : Tasks.Task<ProjectedDocument<'TDocument> option> = 
+            member x.GetDocument<'TDocument> accessMode key : Tasks.Task<ProjectedDocument<'TDocument> option> = 
                 async {
                     return None 
                 } |> Async.StartAsTask
@@ -36,7 +36,7 @@ type RavenReplayProjector<'TMessage when 'TMessage :> IBulkMessage>
                 async {
                     return
                         request
-                        |> Seq.map(fun (a,b) -> (a,b,None))
+                        |> Seq.map(fun { DocumentKey = a; DocumentType = b } -> (a,b,None))
                 } |> Async.StartAsTask
 
             member x.GetEmptyMetadata<'TDocument> () =

--- a/src/Eventful.Tests.Integration/RavenOperationTests.fs
+++ b/src/Eventful.Tests.Integration/RavenOperationTests.fs
@@ -25,7 +25,7 @@ module RavenOperationTests =
     [<Fact>]
     let ``Retrieve non existent doc`` () : unit =
         let documentStore = buildDocumentStore() :> Raven.Client.IDocumentStore 
-        let cache = new MemoryCache("TestCache")
+        let cache = new RavenMemoryCache("TestCache", documentStore)
 
         let docKey = "DoesNotExist"
         let result = 
@@ -33,7 +33,7 @@ module RavenOperationTests =
                 documentStore 
                 cache 
                 testDb
-                (Seq.singleton (docKey, typeof<MyDoc>)) 
+                (Seq.singleton { DocumentKey = docKey; DocumentType = typeof<MyDoc>; AccessMode = AccessMode.Read }) 
             |> Async.RunSynchronously
 
         result |> Seq.length |> should equal 1
@@ -47,7 +47,7 @@ module RavenOperationTests =
     [<Fact>]
     let ``Retrieve existing doc not in cache`` () : unit =
         let documentStore = buildDocumentStore() :> Raven.Client.IDocumentStore 
-        let cache = new MemoryCache("TestCache")
+        let cache = new RavenMemoryCache("TestCache", documentStore)
 
         let docKey = "MyDocs/" + Guid.NewGuid().ToString()
         let doc = {
@@ -67,7 +67,7 @@ module RavenOperationTests =
                 documentStore 
                 cache 
                 testDb
-                (Seq.singleton (docKey, typeof<MyDoc>)) 
+                (Seq.singleton { DocumentKey = docKey; DocumentType = typeof<MyDoc>; AccessMode = AccessMode.Read }) 
             |> Async.RunSynchronously
 
         result |> Seq.length |> should equal 1

--- a/src/Eventful.Tests.Integration/RavenProjectorTests.fs
+++ b/src/Eventful.Tests.Integration/RavenProjectorTests.fs
@@ -207,12 +207,12 @@ module RavenProjectorTests =
             let docKey = countingDocKey docId
             let permDocKey = "PermissionDocs/" + (docKey.ToString())
             let! (doc, metadata, etag) =  
-                fetcher.GetDocument docKey
+                fetcher.GetDocument AccessMode.Update docKey
                 |> Async.AwaitTask
                 |> Async.map (Option.getOrElseF (fun () -> buildNewDoc docId))
                
             let! (permDoc, permMetadata, permEtag) =
-                fetcher.GetDocument permDocKey
+                fetcher.GetDocument AccessMode.Update permDocKey
                 |> Async.AwaitTask
                 |> Async.map (Option.getOrElseF (fun () -> ({ Id = permDocKey; Writes = 0 }, (RavenOperations.emptyMetadata<MyPermissionDoc> documentStore), Etag.Empty)))
 
@@ -261,7 +261,7 @@ module RavenProjectorTests =
     let testDatabase = "tenancy-blue"
 
     let buildRavenProjector documentStore documentProjectors onWriteComplete = 
-        let cache = new System.Runtime.Caching.MemoryCache("RavenBatchWrite")
+        let cache = new RavenMemoryCache("RavenBatchWrite", documentStore)
 
         let cancellationToken = Async.DefaultCancellationToken
 

--- a/src/Eventful.Tests.Integration/RavenReplayProjectorTests.fs
+++ b/src/Eventful.Tests.Integration/RavenReplayProjectorTests.fs
@@ -25,7 +25,7 @@ module RavenReplayProjectorTests =
         let myProjector = RavenProjectorTests.``Get Projector`` documentStore (async.Zero())
 
         let cancellationToken = Async.DefaultCancellationToken
-        let cache = new System.Runtime.Caching.MemoryCache("RavenBatchWrite")
+        let cache = new RavenMemoryCache("RavenBatchWrite", documentStore)
 
         let readQueue = new RavenReadQueue(documentStore, 100, 10000, 10, cancellationToken, cache)
 


### PR DESCRIPTION
This PR fixes potential issues that could occur when a document is read from the cache on one thread at the same time it's being updated on another. Now when a document in cache is to be updated it is cloned before being updated.
