### PR TITLE
replace rel fix

### DIFF
--- a/src/Eventful.Neo4j/Neo4jOperations.fs
+++ b/src/Eventful.Neo4j/Neo4jOperations.fs
@@ -190,14 +190,14 @@ module Operations =
             let query, toSelector = query |> withNodeSelectorQ "to" to'
 
             query
-            |> matchQ (sprintf "%s-[r:`%s`]->%s" fromSelector relationshipType toSelector)
+            |> optionalMatchQ (sprintf "%s-[r:`%s`]->%s" fromSelector relationshipType toSelector)
             |> deleteQ "r"
 
         | RemoveAllIncomingRelationships (node, relationshipType) ->
             let query, selector = query |> withNodeSelectorQ "" node
             
             query
-            |> matchQ (sprintf "()-[r:`%s`]->%s" relationshipType selector)
+            |> optionalMatchQ (sprintf "()-[r:`%s`]->%s" relationshipType selector)
             |> deleteQ "r"
 
         | AddLabels (node, labels) ->


### PR DESCRIPTION
relationship may not exist, if it doesn't and you try to replace it, it won't perform subsequent actions (i.e. the replacements)